### PR TITLE
added Colby logo so it appears in the browser tab

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Photography App</title>
+    <title>Photography Inventory</title>
+    <link rel="icon" href="{{ url_for('static', filename='images/colbyseal.svg') }}">
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
       rel="stylesheet"


### PR DESCRIPTION
 Added the Colby logo (aka the Colby seal) to the index.html header. Now the seal appears as a tab icon within the browser
I also just changed the tab title from Photography App to Photography Inventory.

This closes issue #24

With these two changes, this is what the tab should now look like in the browser. 

<img width="580" height="562" alt="Screenshot 2025-11-06 213715" src="https://github.com/user-attachments/assets/0a444f0d-bd60-4836-8c72-8d869d2ecffc" />
