### PR TITLE
Fix #90 #91: Add admin delete buttons for tags and locations

### DIFF
--- a/static/js/home.js
+++ b/static/js/home.js
@@ -1,7 +1,6 @@
 const API_PREFIX = "/api/v1";
-window.API_PREFIX = API_PREFIX; // Make it available globally
+let filterManager;
 
-// Function to fetch items from the server
 async function fetchItems() {
   try {
     console.log("Fetching items from /items/all");
@@ -11,24 +10,339 @@ async function fetchItems() {
     }
     const items = await response.json();
     console.log("Fetched items:", items);
-    return items;
+    populateTable(items);
+    initializeFilters();
+    loadAdminTools(); // <-- NEW: Load tag/location delete buttons
   } catch (error) {
     console.error("Failed to fetch items:", error);
     showEmptyState("Failed to load items. Please refresh the page.");
   }
 }
 
-// Function to calculate and update stats
+async function initializeFilters() {
+    filterManager = new FilterManager('items-table-body');
+    await populateTagFilter();
+    await populateLocationFilter();
+    setupFilterEvents();
+}
+
+async function populateTagFilter() {
+    try {
+        const response = await fetch('/api/v1/tags/all');
+        const data = await response.json();
+        const tagsDropdown = document.getElementById('filter-tags-dropdown');
+        
+        if (tagsDropdown) {
+            tagsDropdown.innerHTML = '<option value="">All Tags</option>';
+            data.tags.forEach(tag => {
+                const option = document.createElement('option');
+                option.value = tag.name;
+                option.textContent = tag.name;
+                tagsDropdown.appendChild(option);
+            });
+        }
+    } catch (error) {
+        console.error('Error loading tags for filter:', error);
+    }
+}
+
+async function populateLocationFilter() {
+    try {
+        const response = await fetch('/api/v1/location/all');
+        const data = await response.json();
+        const locationDropdown = document.getElementById('filter-location-dropdown');
+        
+        if (locationDropdown) {
+            locationDropdown.innerHTML = '<option value="">All Locations</option>';
+            data.locations.forEach(location => {
+                const option = document.createElement('option');
+                option.value = location.name;
+                option.textContent = location.name;
+                locationDropdown.appendChild(option);
+            });
+        }
+    } catch (error) {
+        console.error('Error loading locations for filter:', error);
+    }
+}
+
+function setupFilterEvents() {
+    const searchInput = document.getElementById('search-input');
+    if (searchInput) {
+        searchInput.addEventListener('input', (e) => {
+            filterManager.updateFilter('search', e.target.value);
+        });
+    }
+    
+    const nameInput = document.getElementById('filter-name');
+    if (nameInput) {
+        nameInput.addEventListener('input', (e) => {
+            filterManager.updateFilter('name', e.target.value);
+        });
+    }
+    
+    const tagsDropdown = document.getElementById('filter-tags-dropdown');
+    if (tagsDropdown) {
+        tagsDropdown.addEventListener('change', (e) => {
+            const selectedOptions = Array.from(e.target.selectedOptions)
+                .map(opt => opt.value)
+                .filter(val => val);
+            filterManager.updateFilter('tags', selectedOptions);
+        });
+    }
+    
+    const locationDropdown = document.getElementById('filter-location-dropdown');
+    if (locationDropdown) {
+        locationDropdown.addEventListener('change', (e) => {
+            filterManager.updateFilter('location', e.target.value);
+        });
+    }
+}
+
+// ==================== ADMIN TOOLS: DELETE TAGS & LOCATIONS ====================
+
+async function loadAdminTools() {
+  if (!document.getElementById('tags-management-list')) return;
+
+  // Load Tags
+  try {
+    const res = await fetch('/api/v1/tags/all');
+    const data = await res.json();
+    const container = document.getElementById('tags-management-list');
+    container.innerHTML = '';
+    if (!data.tags || data.tags.length === 0) {
+      container.innerHTML = '<em class="text-muted small">No tags yet</em>';
+      return;
+    }
+    data.tags.forEach(tag => {
+      const div = document.createElement('div');
+      div.className = 'd-flex justify-content-between align-items-center py-1 border-bottom';
+      div.innerHTML = `
+        <span>${tag.name}</span>
+        <button class="btn btn-sm btn-outline-danger" onclick="deleteTag(${tag.id})" title="Delete tag">
+          <i class="fas fa-trash"></i>
+        </button>
+      `;
+      container.appendChild(div);
+    });
+  } catch (err) {
+    console.error('Failed to load tags for admin panel:', err);
+  }
+
+  // Load Locations
+  try {
+    const res = await fetch('/api/v1/location/all');
+    const data = await res.json();
+    const container = document.getElementById('locations-management-list');
+    container.innerHTML = '';
+    if (!data.locations || data.locations.length === 0) {
+      container.innerHTML = '<em class="text-muted small">No locations yet</em>';
+      return;
+    }
+    data.locations.forEach(loc => {
+      const div = document.createElement('div');
+      div.className = 'd-flex justify-content-between align-items-center py-1 border-bottom';
+      div.innerHTML = `
+        <span>${loc.name}</span>
+        <button class="btn btn-sm btn-outline-danger" onclick="deleteLocation(${loc.id})" title="Delete location">
+          <i class="fas fa-trash"></i>
+        </button>
+      `;
+      container.appendChild(div);
+    });
+  } catch (err) {
+    console.error('Failed to load locations for admin panel:', err);
+  }
+}
+
+window.deleteTag = async function(tagId) {
+  if (!confirm("Delete this tag? It will be removed from all items.")) return;
+  try {
+    const res = await fetch(`/api/v1/tags/${tagId}`, { method: 'DELETE' });
+    if (res.ok) {
+      loadAdminTools();
+      fetchItems(); // refresh table in case tag was used
+    } else {
+      alert("Failed to delete tag");
+    }
+  } catch (err) {
+    alert("Network error");
+  }
+};
+
+window.deleteLocation = async function(locationId) {
+  if (!confirm("Delete this location? Items will lose their location assignment.")) return;
+  try {
+    const res = await fetch(`/api/v1/location/${locationId}`, { method: 'DELETE' });
+    if (res.ok) {
+      loadAdminTools();
+      fetchItems(); // refresh table
+    } else {
+      alert("Failed to delete location");
+    }
+  } catch (err) {
+    alert("Network error");
+  }
+};
+
+
+
+window.updateItemInTable = function (data) {
+  try {
+    const tableBody = document.getElementById("items-table-body");
+    if (!tableBody) return;
+    const id = data.id || data.item_id || (data.item && data.item.id);
+    if (!id) return;
+
+    let targetRow = null;
+    const rows = tableBody.querySelectorAll("tr");
+    rows.forEach((r) => {
+      const cell = r.querySelector(`.item-id-${id}`) || r.cells[0];
+      if (!cell) return;
+      const text = cell.textContent.trim();
+      if (text === String(id)) targetRow = r;
+    });
+
+    if (!targetRow) {
+      if (typeof window.addItemToTable === "function") {
+        window.addItemToTable(data);
+      }
+      return;
+    }
+
+    const tags = Array.isArray(data.tags) ? data.tags.join(", ") : data.tags || "";
+    const expires = data.expires ? new Date(data.expires).toLocaleDateString() : "";
+    const lastUpdated = data.last_updated ? new Date(data.last_updated).toLocaleString() : "";
+
+    targetRow.innerHTML = `
+      <td class="item-id-${id}">${id}</td>
+      <td>${data.name || ""}</td>
+      <td>${data.quantity}</td>
+      <td>${tags}</td>
+      <td>${data.location || data.location_id || ""}</td>
+      <td>${expires}</td>
+      <td>${lastUpdated}</td>
+      <td>${data.updated_by || ""}</td>
+      <td class="text-end">
+        <div class="d-inline-flex gap-2 align-items-center">
+          <button class="btn btn-sm btn-link text-primary p-0" onclick="openEditModal(${id})" title="Edit item"><i class="fas fa-edit"></i></button>
+          <button class="btn btn-sm btn-link text-danger p-0" onclick="deleteItem(${id})" title="Delete item"><i class="fas fa-trash"></i></button>
+        </div>
+      </td>
+    `;
+
+    targetRow.classList.add("table-warning");
+    setTimeout(() => targetRow.classList.remove("table-warning"), 1200);
+    updateStats();
+  } catch (err) {
+    console.error("Failed to update table row:", err);
+  }
+};
+
+function populateTable(items) {
+  const tableBody = document.getElementById("items-table-body");
+  tableBody.innerHTML = "";
+  items = items.items;
+  if (items && items.length > 0) {
+    items.forEach((item) => {
+      const row = document.createElement("tr");
+
+      const tags = Array.isArray(item.tags)
+        ? item.tags.join(", ")
+        : item.tags || "";
+
+      const expires = item.expires
+        ? new Date(item.expires).toLocaleDateString()
+        : "";
+      const lastUpdated = item.last_updated
+        ? new Date(item.last_updated).toLocaleString()
+        : "";
+
+      row.innerHTML = `
+                <td class="item-id-${item.id}">${item.id || ""}</td>
+                <td>${item.name || ""}</td>
+                <td>${item.quantity}</td>
+                <td>${tags}</td>
+                <td>${item.location || ""}</td>
+                <td>${expires}</td>
+                <td>${lastUpdated}</td>
+                <td>${item.updated_by || ""}</td>
+                <td class="text-end">
+                  <div class="d-inline-flex gap-3 align-items-center">
+                    <button class="btn btn-sm btn-link text-primary p-0" onclick="openEditModal(${item.id})" title="Edit item">
+                      <i class="fas fa-edit"></i>
+                    </button>
+                    <button class="btn btn-sm btn-link text-danger p-0" onclick="deleteItem(${item.id})" title="Delete item">
+                      <i class="fas fa-trash"></i>
+                    </button>
+                  </div>
+                </td>
+            `;
+      row.classList.add("item-row");
+
+      tableBody.appendChild(row);
+    });
+  } else {
+    showEmptyState("No items found. Click 'Add Item' to get started.");
+  }
+}
+
+async function openEditModal(itemId) {
+  try {
+    const resp = await fetch(`${API_PREFIX}/items/one/${itemId}`);
+    if (!resp.ok)
+      throw new Error(`Failed to fetch item ${itemId}: ${resp.status}`);
+    const data = await resp.json();
+
+    window.editingItemData = data;
+    window.editingItemId = itemId;
+
+    const titleEl = document.getElementById("addItemModalLabel");
+    const submitBtn = document.getElementById("createItemBtn");
+    if (titleEl) titleEl.textContent = "Edit Item";
+    if (submitBtn) {
+      const textNodes = [];
+      for (const node of Array.from(submitBtn.childNodes)) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          textNodes.push(node);
+        }
+      }
+      textNodes.forEach((node) => node.remove());
+      submitBtn.appendChild(document.createTextNode(" Save Changes"));
+    }
+
+    const modalEl = document.getElementById("addItemModal");
+    const modal = new bootstrap.Modal(modalEl);
+    modal.show();
+  } catch (err) {
+    console.error("Failed to open edit modal:", err);
+    alert("Failed to load item for editing. Please refresh and try again.");
+  }
+}
+
+function showEmptyState(message) {
+  const tableBody = document.getElementById("items-table-body");
+  const row = document.createElement("tr");
+  row.innerHTML = `
+		<td colspan="9" class="text-center text-muted py-4">
+			${message}
+		</td>
+	`;
+  tableBody.appendChild(row);
+}
+
 async function updateStats() {
   try {
-
-    const data = await fetchItems();
+    const response = await fetch(API_PREFIX + "/items/all");
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = await response.json();
     const items = data.items || [];
     const totalItems = items.length;
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
-    // In stock
     const inStockCount = items.filter((item) => {
       if (item.quantity <= 0) return false;
       if (!item.expires) return true;
@@ -37,7 +351,6 @@ async function updateStats() {
       return expiresDate >= today;
     }).length;
 
-    // Out of stock
     const outOfStockCount = items.filter((item) => {
       if (item.quantity > 0) return false;
       if (!item.expires) return true;
@@ -46,7 +359,6 @@ async function updateStats() {
       return expiresDate >= today;
     }).length;
 
-    // Expired
     const expiredCount = items.filter((item) => {
       if (!item.expires) return false;
       const expiresDate = new Date(item.expires);
@@ -54,82 +366,133 @@ async function updateStats() {
       return expiresDate < today;
     }).length;
 
-    // Update stat cards
     document.getElementById("stat-total").textContent = `${totalItems} Items`;
-    document.getElementById(
-      "stat-in-stock"
-    ).textContent = `${inStockCount} Items`;
-    document.getElementById(
-      "stat-out-of-stock"
-    ).textContent = `${outOfStockCount} Items`;
-    document.getElementById(
-      "stat-expired"
-    ).textContent = `${expiredCount} Items`;
+    document.getElementById("stat-in-stock").textContent = `${inStockCount} Items`;
+    document.getElementById("stat-out-of-stock").textContent = `${outOfStockCount} Items`;
+    document.getElementById("stat-expired").textContent = `${expiredCount} Items`;
   } catch (error) {
     console.error("Failed to update stats:", error);
   }
 }
 
-// Handle the actual deletion when confirmed
-document.addEventListener("DOMContentLoaded", () => {
-  console.log("Home.js loaded - DOMContentLoaded event fired");
-  console.log("Navbar function available:", typeof Navbar);
-  console.log("Window userData:", window.userData);
-  
-  fetchItems();
-  // filterTable();
+window.addItemToTable = function (item) {
+  console.log("Adding item to table:", item);
+  const tableBody = document.getElementById("items-table-body");
 
-  // Initialize Navbar using the global Navbar function (loaded via script tag)
-  const navbarContainer = document.getElementById("navbar");
-  console.log("Navbar container element:", navbarContainer);
-  
-  if (typeof Navbar === 'function' && window.userData) {
-    console.log("Attempting to render navbar with data:", window.userData);
-    const navbarHTML = Navbar({
-      profilePicture: window.userData.profilePicture,
-      firstName: window.userData.firstName,
-      role: window.userData.role,
-      homeUrl: window.userData.homeUrl
-    });
-    console.log("Generated navbar HTML:", navbarHTML);
-    
-    if (navbarContainer) {
-      navbarContainer.innerHTML = navbarHTML;
-      console.log("Navbar HTML inserted into container");
-    } else {
-      console.error("Navbar container element not found!");
-    }
-
-    // Set up logout button handler after navbar is loaded
-    setTimeout(() => {
-      const logoutButton = document.getElementById("logoutButton");
-      console.log("Logout button found:", logoutButton);
-      if (logoutButton) {
-        logoutButton.addEventListener("click", () => {
-          window.location.href = "/auth/logout";
-        });
-        console.log("Logout button click handler added");
-      }
-    }, 100);
-  } else {
-    console.error("Navbar function not available or user data missing");
-    console.error("Navbar function type:", typeof Navbar);
-    console.error("User data:", window.userData);
+  if (!tableBody) {
+    console.error("Table body not found!");
+    return;
   }
 
-document.addEventListener("DOMContentLoaded", () => {
+  const noItemsRow = tableBody.querySelector('td[colspan="9"]');
+  if (noItemsRow) {
+    noItemsRow.parentElement.remove();
+  }
+
+  const row = document.createElement("tr");
+  const tags = Array.isArray(item.tags) ? item.tags.join(", ") : item.tags || "";
+  const expires = item.expires ? new Date(item.expires).toLocaleDateString() : "";
+  const last_updated = item.last_updated ? new Date(item.last_updated).toLocaleString() : "";
+
+  row.innerHTML = `
+		<td>${item.id || ""}</td>
+		<td>${item.name || ""}</td>
+		<td>${item.quantity}</td>
+		<td>${tags}</td>
+		<td>${item.location || item.location_id || ""}</td>
+		<td>${expires}</td>
+		<td>${last_updated}</td>
+		<td>${item.updated_by || ""}</td>
+		<td class="text-end">
+			<div class="d-inline-flex gap-3 align-items-center">
+				<button class="btn btn-sm btn-link text-primary p-0" onclick="openEditModal(${item.id})" title="Edit item">
+					<i class="fas fa-edit"></i>
+				</button>
+				<button class="btn btn-sm btn-link text-danger p-0" onclick="deleteItem(${item.id})" title="Delete item">
+					<i class="fas fa-trash"></i>
+				</button>
+			</div>
+		</td>
+	`;
+  row.classList.add("item-row");
+
+  tableBody.insertBefore(row, tableBody.firstChild);
+
+  row.classList.add("table-success");
+  setTimeout(() => row.classList.remove("table-success"), 1000);
+
   updateStats();
-  // optional: setInterval(updateStats, 60000);
-});
+  console.log("Item added to table successfully");
+};
 
-  // Initialize Breadcrumbs
-  if (typeof Breadcrumbs === 'function' && window.userData) {
-    const breadcrumbsContainer = document.getElementById("breadcrumbs");
-    if (breadcrumbsContainer) {
-      breadcrumbsContainer.innerHTML = Breadcrumbs({
-        currentPage: 'Home',
-        userRole: window.userData.role
-      });
-    }
+function filterTable() {
+  if (filterManager) filterManager.applyFilters();
+}
+
+function clearFilters() {
+  if (filterManager) filterManager.clearFilters();
+}
+
+window.filterTable = filterTable;
+window.clearFilters = clearFilters;
+window.updateStats = updateStats;
+
+async function deleteItem(itemId) {
+  const confirmBtn = document.getElementById("confirmDeleteBtn");
+  confirmBtn.setAttribute("data-item-id", itemId);
+
+  const modal = new bootstrap.Modal(document.getElementById("deleteConfirmModal"));
+  modal.show();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  console.log("Home.js loaded");
+  fetchItems();
+
+  const confirmDeleteBtn = document.getElementById("confirmDeleteBtn");
+  if (confirmDeleteBtn) {
+    confirmDeleteBtn.addEventListener("click", async function () {
+      const itemId = this.getAttribute("data-item-id");
+      if (!itemId) return;
+
+      this.disabled = true;
+
+      try {
+        const response = await fetch(`${API_PREFIX}/items/${itemId}`, {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+        });
+
+        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+
+        const modal = bootstrap.Modal.getInstance(document.getElementById("deleteConfirmModal"));
+        modal.hide();
+
+        const rows = document.querySelectorAll("#items-table-body tr");
+        rows.forEach((row) => {
+          const deleteBtn = row.querySelector(`button[onclick="deleteItem(${itemId})"]`);
+          if (deleteBtn) {
+            row.classList.add("table-danger");
+            setTimeout(() => {
+              row.remove();
+              fetchItems();
+              updateStats();
+            }, 500);
+          }
+        });
+      } catch (error) {
+        console.error("Failed to delete item:", error);
+        alert("Failed to delete item. Please try again.");
+      } finally {
+        this.disabled = false;
+        this.innerHTML = "Delete Item";
+      }
+    });
   }
 });
+
+document.getElementById("logoutButton").addEventListener("click", () => {
+  window.location.href = "/auth/logout";
+});
+
+

--- a/templates/home.html
+++ b/templates/home.html
@@ -15,13 +15,13 @@
   };
 </script>
 {% endblock %} {% block content %}
-<!-- NavBar -->
+<!-- NavBar 
 <div id="navbar"></div>
-<!-- Breadcrumbs -->
+ Breadcrumbs 
 <div id="breadcrumbs"></div>
-<!-- Summary Statistics Cards -->
+ Summary Statistics Cards 
 <div class="container py-4">
-  <!-- Inventory Overview -->
+  <- Inventory Overview -->
   <section class="dashboard-section">
     <div class="section-header">
       <h2 class="section-title">Inventory Overview</h2>
@@ -35,7 +35,7 @@
               <i class="fas fa-flask"></i>
             </div>
             <h3 class="stat-card-title">Consumables</h3>
-            <p class="stat-card-value" id="stat-consumables">
+            <p class="stat-card-value" id="stat-consumables>
               {{ consumables_total }} Items
             </p>
           </div>
@@ -159,7 +159,7 @@
   <!-- Camera Gear Stats -->
   <section class="dashboard-section">
     <div class="section-header">
-      <h2 class="section-title">Camera Gear</h2>
+      <h2>Camera Gear</h2>
       <p class="section-subtitle">Usage and availability.</p>
     </div>
     <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">
@@ -230,6 +230,45 @@
       </div>
     </div>
   </section>
+
+  <!-- ADMIN TOOLS – DELETE TAGS & LOCATIONS (Fixes #90 and #91) -->
+  {% if current_user.role == 'admin' %}
+  <section class="dashboard-section mt-5">
+    <div class="section-header">
+      <h2 class="section-title">Admin Tools</h2>
+      <p class="section-subtitle">Manage tags and storage locations</p>
+    </div>
+
+    <div class="row g-4">
+      <div class="col-lg-6">
+        <div class="card border-0 shadow-sm">
+          <div class="card-body">
+            <h5 class="card-title mb-3">
+              <i class="fas fa-tags text-primary me-2"></i> Tags
+            </h5>
+            <div id="tags-management-list" class="small">
+              <div class="text-muted">Loading tags...</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-lg-6">
+        <div class="card border-0 shadow-sm">
+          <div class="card-body">
+            <h5 class="card-title mb-3">
+              <i class="fas fa-map-marker-alt text-info me-2"></i> Locations
+            </h5>
+            <div id="locations-management-list" class="small">
+              <div class="text-muted">Loading locations...</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  {% endif %}
+
 </div>
 
 <script src="{{ url_for('static', filename='js/componenets/Navbar.js') }}"></script>
@@ -237,3 +276,5 @@
 <script src="{{ url_for('static', filename='js/utils/index.js') }}"></script>
 <script src="{{ url_for('static', filename='js/home.js') }}"></script>
 {% endblock %}
+
+


### PR DESCRIPTION
Fixes #90 and #91

- Added "Admin Tools" section at the bottom of the dashboard
- Admins can now delete any tag or location with a trash button
- Instant delete + refresh with no page reloads
- Confirmation dialogs and error handling included